### PR TITLE
Feat: Automatic Event Creation

### DIFF
--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -253,7 +253,7 @@ namespace GlobalCompetitionSystem
         }
 
         // >> Creates a random competition event with varied parameters.
-        // >> Currently supports fish collection competitions with randomized rewards and durations.
+        // >> Randomly selects between MostFish, LargestFish, and MostItems competition types.
         [Server]
         private static void CreateRandomEvent()
         {
@@ -303,11 +303,40 @@ namespace GlobalCompetitionSystem
             
             ItemDefinition selectedFish = fishItems[UnityEngine.Random.Range(0, fishItems.Count)];
             
-            // Create competition state
-            MostItemsCompetitonState state = new MostItemsCompetitonState
+            // Randomly select competition type (33% each)
+            int competitionType = UnityEngine.Random.Range(0, 3);
+            ICompetitionState state;
+            string eventDescription;
+            
+            switch (competitionType)
             {
-                ItemId = selectedFish.Id
-            };
+                case 0: // Most Fish Competition
+                    state = new MostFishCompetitonState
+                    {
+                        specificFish = true,
+                        fishIDToCatch = selectedFish.Id
+                    };
+                    eventDescription = $"Catch the most {selectedFish.DisplayName}";
+                    break;
+                    
+                case 1: // Largest Fish Competition
+                    state = new largestFishCompetitonState
+                    {
+                        specificFish = true,
+                        fishIDToCatch = selectedFish.Id
+                    };
+                    eventDescription = $"Catch the biggest {selectedFish.DisplayName}";
+                    break;
+                    
+                case 2: // Most Items Competition
+                default:
+                    state = new MostItemsCompetitonState
+                    {
+                        ItemId = selectedFish.Id
+                    };
+                    eventDescription = $"Collect the most {selectedFish.DisplayName}";
+                    break;
+            }
             
             // Randomize currency type (70% coins, 30% bucks for rarer rewards)
             StoreManager.CurrencyType currency = UnityEngine.Random.value < 0.7f 
@@ -317,7 +346,7 @@ namespace GlobalCompetitionSystem
             // Generate prize distribution based on currency type
             List<int> prizeDistribution = GeneratePrizeDistribution(currency);
             
-            Debug.Log($"[CompetitionManager] Created event: Collect {selectedFish.DisplayName} | Start: {startDate:yyyy-MM-dd HH:mm} | Duration: {durationHours}h | Currency: {currency}");
+            Debug.Log($"[CompetitionManager] Created event: {eventDescription} | Start: {startDate:yyyy-MM-dd HH:mm} | Duration: {durationHours}h | Currency: {currency}");
             
             AddUpcomingCompetition(state, startDate, endDate, currency, prizeDistribution);
         }

--- a/Assets/Core/Managers/GameNetworkManager.cs
+++ b/Assets/Core/Managers/GameNetworkManager.cs
@@ -128,6 +128,7 @@ public class GameNetworkManager : NetworkManager
         NetworkServer.RegisterHandler<MovePlayerMessage>(OnPlayerMoveMessage);
         
         StartCoroutine(CompetitionManager.UpdateCompetitions());
+        StartCoroutine(CompetitionManager.AutoGenerateEvents());
     }
 
     [Client]

--- a/Assets/Core/Networking/WebRequestHandlerInterface.cs
+++ b/Assets/Core/Networking/WebRequestHandlerInterface.cs
@@ -92,6 +92,13 @@ public static class WebRequestHandler
         ongoingRequests.Add(new RequestMessageData(connection, request, objects, callback));
     }
 
+    public static void SendGetRequest(string url, WebRequestCallback callback)
+    {
+        UnityWebRequest request = UnityWebRequest.Get(url);
+        request.SendWebRequest();
+        ongoingRequests.Add(new RequestMessageData(null, request, null, callback));
+    }
+
     public static void CheckOngoingRequests()
     {
         //Reverse order because it does remove items inside the loop and will skip over items if done from the front

--- a/Assets/Database communication/DatabaseCommunications.cs
+++ b/Assets/Database communication/DatabaseCommunications.cs
@@ -292,4 +292,46 @@ public static class DatabaseCommunications
         byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
         WebRequestHandler.SendWebRequest(DatabaseEndpoints.removeExpiredEffectEndpoint, bodyRaw);
     }
+
+    // Competition endpoints
+    [Server]
+    public static void GetActiveCompetitions(WebRequestHandler.WebRequestCallback callback)
+    {
+        WebRequestHandler.SendGetRequest(DatabaseEndpoints.getActiveCompetitionsEndpoint, callback);
+    }
+
+    [Server]
+    public static void GetUpcomingCompetitions(WebRequestHandler.WebRequestCallback callback)
+    {
+        WebRequestHandler.SendGetRequest(DatabaseEndpoints.getUpcomingCompetitionsEndpoint, callback);
+    }
+
+    [Server]
+    public static void UpdateCompetitionScore(Guid competitionId, Guid userId, string userName, int score)
+    {
+        UpdateCompetitionScoreRequest requestData = new UpdateCompetitionScoreRequest
+        {
+            competition_id = competitionId.ToString(),
+            user_id = userId.ToString(),
+            user_name = userName,
+            score = score
+        };
+
+        string json = JsonUtility.ToJson(requestData);
+        byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+        WebRequestHandler.SendWebRequest(DatabaseEndpoints.updateCompetitionScoreEndpoint, bodyRaw);
+    }
+
+    [Server]
+    public static void GenerateCompetitions(int count, WebRequestHandler.WebRequestCallback callback)
+    {
+        GenerateCompetitionsRequest requestData = new GenerateCompetitionsRequest
+        {
+            count = count
+        };
+
+        string json = JsonUtility.ToJson(requestData);
+        byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+        WebRequestHandler.SendWebRequest(DatabaseEndpoints.generateCompetitionsEndpoint, bodyRaw, callback);
+    }
 }

--- a/Assets/Database communication/DatabaseEndpoints.cs
+++ b/Assets/Database communication/DatabaseEndpoints.cs
@@ -28,5 +28,8 @@ public static class DatabaseEndpoints
     public static string addActiveEffectEndpoint = serverAddress + "effects/add_effect";
     public static string removeExpiredEffectEndpoint = serverAddress + "effects/remove_expired";
     
-    public static string getPlayerDataEndpoint = serverAddress + "data/retreive_all_playerdata";
-}
+    public static string getPlayerDataEndpoint = serverAddress + "data/retreive_all_playerdata";    
+    public static string getActiveCompetitionsEndpoint = serverAddress + "competitions/active";
+    public static string getUpcomingCompetitionsEndpoint = serverAddress + "competitions/upcoming";
+    public static string updateCompetitionScoreEndpoint = serverAddress + "competitions/update_score";
+    public static string generateCompetitionsEndpoint = serverAddress + "competitions/generate";}

--- a/Assets/Database communication/DatabaseRequestStructs.cs
+++ b/Assets/Database communication/DatabaseRequestStructs.cs
@@ -194,4 +194,75 @@ public class RemoveExpiredEffectsRequest
     public int item_id;
 }
 
+// Competition requests and responses
+[Serializable]
+public class CompetitionResponse
+{
+    public string competition_id;
+    public int competition_type; // 1=MostFish, 2=MostItems, 3=LargestFish
+    public int target_fish_id;
+    public string start_time; // ISO 8601 UTC
+    public string end_time; // ISO 8601 UTC
+    public string reward_currency; // "coins" or "bucks"
+    public int prize_1st;
+    public int prize_2nd;
+    public int prize_3rd;
+    public int prize_4th;
+    public int prize_5th;
+    public int prize_6th;
+    public int prize_7th;
+    public int prize_8th;
+    public int prize_9th;
+    public int prize_10th;
+    public string created_at;
+}
+
+[Serializable]
+public class CompetitionParticipantResponse
+{
+    public string competition_id;
+    public string user_id;
+    public string user_name;
+    public int score;
+    public string last_updated;
+}
+
+[Serializable]
+public class CompetitionWithLeaderboardResponse
+{
+    public string competition_id;
+    public int competition_type;
+    public int target_fish_id;
+    public string start_time;
+    public string end_time;
+    public string reward_currency;
+    public int prize_1st;
+    public int prize_2nd;
+    public int prize_3rd;
+    public int prize_4th;
+    public int prize_5th;
+    public int prize_6th;
+    public int prize_7th;
+    public int prize_8th;
+    public int prize_9th;
+    public int prize_10th;
+    public string created_at;
+    public CompetitionParticipantResponse[] leaderboard;
+}
+
+[Serializable]
+public class UpdateCompetitionScoreRequest
+{
+    public string competition_id;
+    public string user_id;
+    public string user_name;
+    public int score;
+}
+
+[Serializable]
+public class GenerateCompetitionsRequest
+{
+    public int count;
+}
+
 #nullable disable

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -194,7 +194,7 @@ This file tracks all TODOs identified throughout the codebase, as well as planne
   - Improves security by preventing simultaneous logins
 
 ### Events System
-- [ ] **Automatic event creation**: Develop a system that automatically generates and schedules new in-game events
+- [X] **Automatic event creation**: Develop a system that automatically generates and schedules new in-game events
   - Should create events on a regular basis
   - Events should be varied and engaging for players
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,214 @@
+# Project TODO List
+
+This file tracks all TODOs identified throughout the codebase, as well as planned features that have not yet been fully implemented or documented with a TODO comment.
+
+
+## Marked TODO's
+
+### Assets/Authenticate/PlayerAuthenticator.cs
+- [ ] Line 321: Let Ronald look at this when I implemented security
+
+### Assets/Core/Player/PlayerData.cs
+- [ ] Line 52: Fishao used bezier curves for it's line, I might need to do the same
+- [ ] Line 428: Make a function for in the syncManager, this should do the DB calls
+
+### Assets/Core/Managers/GameNetworkManager.cs
+- [ ] Line 136: Set all other character values like clothes
+- [ ] Line 401: Add clothes that the player wants to wear, and check on the server if this is possible
+
+## Mirror Networking Library
+
+### Assets/Mirror/Transports/Threaded/ThreadedTransport.cs
+- [ ] Line 133: nonalloc
+- [ ] Line 139: nonalloc
+- [ ] Line 205: Recycle writers
+- [ ] Line 213: Deadlock protection. worker thread may be to slow to process all
+- [ ] Line 688: Pass address in OnConnected
+- [ ] Line 742: Cleaner
+
+### Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/WebSocketServer.cs
+- [ ] Line 77: Keep track of connections before they are in connections dictionary
+
+### Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/ReceiveLoop.cs
+- [ ] Line 131: Cache this to avoid allocations
+
+### Assets/Mirror/Transports/KCP/ThreadedKcpTransport.cs
+- [ ] Line 250: Not thread safe
+- [ ] Line 295: Not thread safe
+
+### Assets/Mirror/Transports/Encryption/EncryptionCredentials.cs
+- [ ] Line 30: Load from file
+
+### Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpServer.cs
+- [ ] Line 36: Don't call base. don't listen to local UdpServer at all?
+- [ ] Line 86: Need separate buffer. don't write into result yet. only payload
+
+### Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpPeer.cs
+- [ ] Line 448: KcpConnection is IO agnostic. move this to outside later
+- [ ] Line 497: KcpConnection is IO agnostic. move this to outside later
+- [ ] Line 639: Buffer size check
+- [ ] Line 769: KcpConnection is IO agnostic. move this to outside later
+
+### Assets/Mirror/Transports/Edgegap/EdgegapLobby/Models/LobbyCreateRequest.cs
+- [ ] Line 20: Annotations implementation
+
+### Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServer.cs
+- [ ] Line 326: This allocates a new KcpConnection for each new
+
+### Assets/Mirror/Components/RemoteStatistics.cs
+- [ ] Line 112: Only load once, not for all players?
+- [ ] Line 208: ServerTransport.earlyUpdateDuration.average
+- [ ] Line 209: ServerTransport.lateUpdateDuration.average
+- [ ] Line 313: Uptime display
+- [ ] Line 400: Unspecified
+
+### Assets/Mirror/Core/Batching/Batcher.cs
+- [ ] Line 165: Safely get & return a batch instead of copying to writer?
+- [ ] Line 166: Could return pooled writer & use GetBatch in a 'using' statement!
+
+### Assets/Mirror/Components/PredictedRigidbody/PredictedRigidbody.cs
+- [ ] Line 408: Unspecified
+- [ ] Line 432: Maybe merge the IsMoving() checks & callbacks with UpdateState()
+- [ ] Line 538: Maybe don't reuse the correction thresholds?
+- [ ] Line 828: Maybe we should interpolate this back to 'now'?
+- [ ] Line 854: Only position for now. consider rotation etc. too later
+- [ ] Line 890: We should use the one from FixedUpdate
+
+### Assets/Mirror/Hosting/Edgegap/Editor/EdgegapBuildUtils.cs
+- [ ] Line 402: Use --password-stdin for security (!) This is no easy task for child Process
+
+### Assets/Mirror/Components/LagCompensation/LagCompensator.cs
+- [ ] Line 140: Consider rotations???
+- [ ] Line 141: Consider original collider shape??
+- [ ] Line 176: Rotation??
+- [ ] Line 177: Different collier types??
+
+### Assets/Mirror/Components/LagCompensation/HistoryCollider.cs
+- [ ] Line 65: Double check
+- [ ] Line 94: Projection?
+- [ ] Line 97: Runtime drawing for debugging?
+
+### Assets/Mirror/Core/LagCompensation/LagCompensation.cs
+- [ ] Line 65: Faster version: guess start index by how many 'intervals' we are behind
+
+### Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+- [ ] Line 30: This field is kind of unnecessary since we now support child NetworkBehaviours
+- [ ] Line 203: target.lossyScale = scale
+- [ ] Line 294: What about host mode?
+- [ ] Line 298: The teleported client should ignore the rpc though
+- [ ] Line 301: Or not? if client ONLY calls Teleport(pos), the position
+- [ ] Line 316: What about host mode?
+- [ ] Line 320: The teleported client should ignore the rpc though
+- [ ] Line 323: Or not? if client ONLY calls Teleport(pos), the position
+- [ ] Line 341: What about host mode?
+- [ ] Line 357: What about host mode?
+- [ ] Line 393: Unspecified
+- [ ] Line 418: Unspecified
+
+### Assets/Mirror/Core/LocalConnectionToServer.cs
+- [ ] Line 90: Remove redundant state. have one source of truth for .ready!
+- [ ] Line 103: Should probably be in connectionToClient.DisconnectInternal
+
+### Assets/Mirror/Core/LagCompensation/HistoryBounds.cs
+- [ ] Line 122: Technically we could reuse 'currentBucket' before clearing instead of encapsulating again
+
+### Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
+- [ ] Line 94: Does this also need to sync acceleration so and update velocity?
+
+### Assets/Mirror/Components/NetworkTransform/NetworkTransformHybrid.cs
+- [ ] Line 34: But use built in syncInterval instead of the extra field here!
+- [ ] Line 451: Unspecified
+- [ ] Line 468: Unspecified
+- [ ] Line 486: What about host mode?
+- [ ] Line 502: What about host mode?
+- [ ] Line 515: What about host mode?
+- [ ] Line 519: The teleported client should ignore the rpc though
+- [ ] Line 522: Or not? if client ONLY calls Teleport(pos), the position
+- [ ] Line 537: What about host mode?
+- [ ] Line 541: The teleported client should ignore the rpc though
+- [ ] Line 544: Or not? if client ONLY calls Teleport(pos), the position
+
+### Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+- [ ] Line 205: Dirty mask? [compression is very good w/o it already]
+
+### Assets/Mirror/Core/NetworkBehaviour.cs
+- [ ] Line 104: Change to NetworkConnectionToServer, but might cause some breaking
+- [ ] Line 142: 64 SyncLists are too much. consider smaller mask later
+- [ ] Line 486: Change conn type to NetworkConnectionToClient to begin with
+
+### Assets/Mirror/Core/NetworkBehaviourHybrid.cs
+- [ ] Line 254: Send same time that NetworkServer sends time snapshot?
+
+### Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+- [ ] Line 116: Send same time that NetworkServer sends time snapshot?
+
+### Assets/Mirror/Core/NetworkClient.cs
+- [ ] Line 58: Redundant state. point it to .connection.isReady instead (& test)
+- [ ] Line 59: OR remove NetworkConnection.isReady? unless it's used on server
+- [ ] Line 61: Maybe ClientState.Connected/Ready/AddedPlayer/etc.?
+- [ ] Line 219: Why are there two connect host methods?
+- [ ] Line 243: Move to 'cleanup' code below if safe
+- [ ] Line 641: Likely not necessary anymore due to the new check in
+- [ ] Line 722: Why do we have one with SpawnDelegate and one with SpawnHandlerDelegate?
+- [ ] Line 736: Why do we have one with SpawnDelegate and one with SpawnHandlerDelegate?
+- [ ] Line 777: Why do we have one with SpawnDelegate and one with SpawnHandlerDelegate?
+- [ ] Line 849: Why do we have one with SpawnDelegate and one with SpawnHandlerDelegate?
+- [ ] Line 1046: This is redundant. have one source of truth for .ready
+- [ ] Line 1069: This check might not be necessary
+- [ ] Line 1536: Set .connectionToServer to null for old local player?
+
+### Assets/Mirror/Core/NetworkConnection.cs
+- [ ] Line 20: Move this to ConnectionToClient so the flag only lives on server
+- [ ] Line 66: If we only have Reliable/Unreliable, then we could initialize
+
+### Assets/Mirror/Core/NetworkConnectionToClient.cs
+- [ ] Line 25: Move to server's NetworkConnectionToClient?
+- [ ] Line 34: Move them along server's timeline in the future
+- [ ] Line 139: It would be safer for the server to store the last N
+
+### Assets/Mirror/Editor/Weaver/EntryPointILPostProcessor/ILPostProcessorLogger.cs
+- [ ] Line 16: Add file etc. for double click opening later?
+- [ ] Line 27: IN-44868 FIX IS IN 2021.3.32f1, 2022.3.11f1, 2023.2.0b13 and 2023.3.0a8
+
+### Assets/Mirror/Core/NetworkConnectionToServer.cs
+- [ ] Line 18: Remove redundant state. have one source of truth for .ready!
+
+### Assets/Mirror/Hosting/Edgegap/Editor/EdgegapWindowV2.cs
+- [ ] Line 257: Load persistent data?
+- [ ] Line 819: This will later be a result model
+- [ ] Line 2451: Append "?{EdgegapWindowMetadata.DEFAULT_UTM_TAGS}"
+
+### Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
+- [ ] Line 10: Expose the settings to the user later
+
+### Assets/Mirror/Core/NetworkIdentity.cs
+- [ ] Line 176: Change to NetworkConnectionToServer, but might cause some breaking
+- [ ] Line 696: Report this to Unity!
+
+
+## Planned features
+
+### Authentication & Session Management
+- [ ] **Multi-device logout**: Implement functionality to automatically log out users from other tabs/devices when they log in on a new device or tab
+  - Ensures only one active session per user at a time
+  - Improves security by preventing simultaneous logins
+
+### Events System
+- [ ] **Automatic event creation**: Develop a system that automatically generates and schedules new in-game events
+  - Should create events on a regular basis
+  - Events should be varied and engaging for players
+
+### Daily Missions & NPCs
+- [ ] **Daily quest NPC**: Create a roaming NPC system that spawns in different locations each day
+  - NPC should offer daily missions to players
+  - Missions should reward players with fishcoins
+  - Example mission: "Catch 3 sardines for 3 fishcoins"
+  - NPC location should rotate daily to encourage exploration
+
+### Achievements & Collections
+- [ ] **Achievement system**: Implement a comprehensive achievements/collections feature
+  - Size-based achievements: "Catch a fish larger than 100cm"
+  - Location-based achievements: "Catch all fish species available at the beach"
+  - Rarity-based achievements: "Catch all 1-star fish"
+  - Track player progress and display collection status
+  - Provide rewards for completing achievements


### PR DESCRIPTION
I've implemented the automatic event creation system! Here's what it does:

The system automatically generates and schedules fishing competitions to keep at least 3 events in the queue at all times. It checks once per day and creates new events as needed. Events are scheduled 6-12 hours apart with durations of 12-48 hours each.

For variety, it randomly selects between all 3 existing competition types:
- MostFishCompetition (catch the most of a specific fish)
- LargestFishCompetition (catch the biggest fish by length)
- MostItemsCompetition (collect the most of a specific fish)

Each event randomly picks a fish species from the ItemRegistry and randomly decides whether to reward coins (70% chance) or bucks (30% chance). Top 10 players get prizes with these ranges:

Coins: 1st place gets 800-1200, scaling down to 10th place getting 20-30
Bucks: 1st place gets 80-120, scaling down to 10th place getting 2-4

I looked at shop prices in the asset files to ballpark the rewards, but honestly I made up these amounts based on what felt reasonable for multi-day competitions. What do you think? Should they be higher, lower, or is this about right?

Also, while implementing this I noticed it would be pretty straightforward to add goal-based challenges alongside these leaderboard events. Things like "Catch 10 fish in 45 minutes" or "Catch a fish over 50cm" with shorter durations (30-120 minutes) that reward everyone who completes them instead of just the top players. Should I implement that as a separate feature, or do you want to keep it simple with just the leaderboard competitions for now?

Let me know! :)