### PR TITLE
Feat: Auto Event Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ crashlytics-build.properties
 
 # Ignore auto generated files by Unity when creating the project
 Fishy Game/
+
+# Ignore the database folder
+# Added for easier development, has it's own git repository and should not be included in the main repository
+fishy-game-server-database/

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -9,6 +9,16 @@ using UnityEngine;
 
 namespace GlobalCompetitionSystem
 {
+    /// <summary>
+    /// Competition type enum matching backend values
+    /// </summary>
+    public enum CompetitionType
+    {
+        MostFish = 1,
+        LargestFish = 2,
+        MostItems = 3
+    }
+
     public class Competition
     {
         private readonly Guid _competitionId;
@@ -43,25 +53,27 @@ namespace GlobalCompetitionSystem
             // Parse competition ID
             Guid competitionId = Guid.Parse(backendData.competition_id);
             
+            // Cast backend integer to enum
+            CompetitionType competitionType = (CompetitionType)backendData.competition_type;
+            
             // Map competition type to ICompetitionState
-            // Backend: 1=MostFish, 2=LargestFish, 3=MostItems
-            ICompetitionState competitionState = backendData.competition_type switch
+            ICompetitionState competitionState = competitionType switch
             {
-                1 => new MostFishCompetitonState 
+                CompetitionType.MostFish => new MostFishCompetitonState 
                 { 
                     specificFish = backendData.target_fish_id > 0, 
                     fishIDToCatch = backendData.target_fish_id 
                 },
-                2 => new largestFishCompetitonState 
+                CompetitionType.LargestFish => new largestFishCompetitonState 
                 { 
                     specificFish = backendData.target_fish_id > 0, 
                     fishIDToCatch = backendData.target_fish_id 
                 },
-                3 => new MostItemsCompetitonState 
+                CompetitionType.MostItems => new MostItemsCompetitonState 
                 { 
                     ItemId = backendData.target_fish_id  // target_fish_id is used for item ID in this case
                 },
-                _ => throw new ArgumentException($"Unknown competition type: {backendData.competition_type}")
+                _ => throw new ArgumentException($"Unknown competition type: {competitionType} ({backendData.competition_type})")
             };
             
             // Parse date times (backend sends ISO 8601 UTC strings)
@@ -338,7 +350,8 @@ namespace GlobalCompetitionSystem
                 _upcomingCompetitions.Add(competition);
                 _loadedCompetitionIds.Add(competitionId);
                 
-                Debug.Log($"[CompetitionManager] Added competition {competitionId} (Type: {backendData.competition_type}, Start: {competition.StartDateTime}, End: {competition.EndDateTime})");
+                CompetitionType logType = (CompetitionType)backendData.competition_type;
+                Debug.Log($"[CompetitionManager] Added competition {competitionId} (Type: {logType}, Start: {competition.StartDateTime}, End: {competition.EndDateTime})");
             }
             catch (Exception ex)
             {

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -80,13 +80,8 @@ namespace GlobalCompetitionSystem
             DateTime startTime = DateTime.Parse(backendData.start_time).ToUniversalTime();
             DateTime endTime = DateTime.Parse(backendData.end_time).ToUniversalTime();
             
-            // Map currency
-            StoreManager.CurrencyType currency = backendData.reward_currency switch
-            {
-                "COINS" => StoreManager.CurrencyType.COINS,
-                "BUCKS" => StoreManager.CurrencyType.BUCKS,
-                _ => throw new ArgumentException($"Unknown currency type: {backendData.reward_currency}")
-            };
+            // Parse currency enum from string
+            StoreManager.CurrencyType currency = Enum.Parse<StoreManager.CurrencyType>(backendData.reward_currency);
             
             // Convert prize pool array to list
             List<int> prizePool = new List<int>(backendData.prize_pool);

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -291,8 +291,8 @@ namespace GlobalCompetitionSystem
         {
             Debug.Log("[CompetitionManager] Fetching competitions from backend...");
             
-            // Fetch active competitions
-            DatabaseCommunications.GetActiveCompetitions((response) =>
+            // Fetch active competition
+            DatabaseCommunications.GetActiveCompetition((response) =>
             {
                 if (response != null && response.competitions != null)
                 {

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -229,8 +229,7 @@ namespace GlobalCompetitionSystem
         [SyncVar] private static CurrentCompetition _currentCompetition;
         private static readonly SyncSortedSet<Competition> _upcomingCompetitions = new SyncSortedSet<Competition>(new CompetitionStartDateComparer());
         private static readonly HashSet<Guid> _loadedCompetitionIds = new HashSet<Guid>();
-        private static DateTime _lastBackendPoll = DateTime.MinValue;
-        private static readonly TimeSpan _pollInterval = TimeSpan.FromMinutes(5); // Poll backend every 5 minutes
+        private const float BackendPollIntervalSeconds = 300f;
 
         public static CurrentCompetition GetCurrentCompetition()
         {
@@ -249,19 +248,8 @@ namespace GlobalCompetitionSystem
             // hours, minute, seconds
             TimeSpan timeBetweenRankingRebuilds = new TimeSpan(0, 1, 0);
             
-            // Initial poll on startup (after short delay)
-            yield return new WaitForSeconds(2);
-            FetchCompetitionsFromBackend();
-            
             while (true)
             {
-                // Poll backend for new competitions periodically
-                if (DateTime.UtcNow - _lastBackendPoll > _pollInterval)
-                {
-                    FetchCompetitionsFromBackend();
-                    _lastBackendPoll = DateTime.UtcNow;
-                }
-                
                 if (_currentCompetition == null)
                 {
                     if (_upcomingCompetitions.Count > 0)
@@ -287,6 +275,18 @@ namespace GlobalCompetitionSystem
                     lastRankingRefresh = DateTime.UtcNow;
                 }
                 yield return new WaitForSeconds(1);
+            }
+        }
+
+        [Server]
+        public static IEnumerator PollCompetitionsFromBackend()
+        {
+            yield return new WaitForSeconds(2);
+
+            while (true)
+            {
+                FetchCompetitionsFromBackend();
+                yield return new WaitForSeconds(BackendPollIntervalSeconds);
             }
         }
 

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -296,10 +296,19 @@ namespace GlobalCompetitionSystem
             {
                 if (response != null && response.competitions != null)
                 {
-                    Debug.Log($"[CompetitionManager] Received {response.competitions.Length} active competition(s) from backend");
-                    foreach (var competitionData in response.competitions)
+                    if (response.competitions.Length == 0)
                     {
-                        ProcessBackendCompetition(competitionData);
+                        Debug.Log("[CompetitionManager] No active competitions from backend");
+                    }
+                    else if (response.competitions.Length == 1)
+                    {
+                        Debug.Log("[CompetitionManager] Received 1 active competition from backend");
+                        ProcessBackendCompetition(response.competitions[0]);
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"[CompetitionManager] Received {response.competitions.Length} active competitions from backend, but only one can be active at a time. Processing first competition only.");
+                        ProcessBackendCompetition(response.competitions[0]);
                     }
                 }
             });

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -406,9 +406,8 @@ namespace GlobalCompetitionSystem
             {
                 PlayerResult winner = winners[i + 1]; // winners is 1-indexed (rank 1, 2, 3...)
                 int prizeAmount = prizes[i]; // prizes is 0-indexed
-                bool prizeGiven = false;
                 
-                // Try to give prize to online player
+                // Give prize to online player (offline players will receive prizes from backend)
                 if (GameNetworkManager.connUUID.TryGetValue(winner.PlayerID, out NetworkConnectionToClient playerConnection))
                 {
                     PlayerData playerData = playerConnection.identity.GetComponent<PlayerData>();
@@ -427,16 +426,7 @@ namespace GlobalCompetitionSystem
                             default:
                                 throw new NotSupportedException($"Currency type {_currentCompetition.CompetitionData.RunningCompetition.RewardCurrency} has not yet been implemented as a reward");
                         }
-                        prizeGiven = true;
                     }
-                }
-                
-                // If player is offline, send mail notification (mail system will handle currency delivery)
-                if (!prizeGiven)
-                {
-                    string currencyName = _currentCompetition.CompetitionData.RunningCompetition.RewardCurrency == StoreManager.CurrencyType.COINS ? "Coins" : "Bucks";
-                    SendPrizeMail(winner.PlayerID, winner.PlayerName, i + 1, prizeAmount, currencyName);
-                    Debug.Log($"[CompetitionManager] Sent prize mail to offline player {winner.PlayerName} (Rank {i + 1}): {prizeAmount} {currencyName}");
                 }
             }
         }
@@ -481,22 +471,6 @@ namespace GlobalCompetitionSystem
             }
             
             Debug.Log($"[CompetitionManager] Mailed results to {allParticipants.Count} participant(s)");
-        }
-
-        [Server]
-        private static void SendPrizeMail(Guid playerId, string playerName, int rank, int prizeAmount, string currencyName)
-        {
-            string competitionName = _currentCompetition?.CompetitionData.RunningCompetition.CompetitionState.AsString() ?? "Unknown Competition";
-            
-            string title = $"Competition Prize - Rank #{rank}";
-            string message = $"Congratulations {playerName}!\n\n" +
-                           $"You finished rank #{rank} in the '{competitionName}' competition!\n\n" +
-                           $"Your prize: {prizeAmount} {currencyName}\n\n" +
-                           $"(Note: Prize will be added to your account upon your next login)\n\n" +
-                           $"Thank you for participating!";
-            
-            Mail prizeMail = new Mail(playerId, title, message, "Competition System");
-            DatabaseCommunications.AddMail(prizeMail);
         }
 
         public static bool AddToRunningCompetition<T>(T data, PlayerData playerData)

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -53,8 +53,8 @@ namespace GlobalCompetitionSystem
             // Parse competition ID
             Guid competitionId = Guid.Parse(backendData.competition_id);
             
-            // Cast backend integer to enum
-            CompetitionType competitionType = (CompetitionType)backendData.competition_type;
+            // Parse competition type from string to enum
+            CompetitionType competitionType = Enum.Parse<CompetitionType>(backendData.competition_type);
             
             // Map competition type to ICompetitionState
             ICompetitionState competitionState = competitionType switch
@@ -354,7 +354,7 @@ namespace GlobalCompetitionSystem
                 _upcomingCompetitions.Add(competition);
                 _loadedCompetitionIds.Add(competitionId);
                 
-                CompetitionType logType = (CompetitionType)backendData.competition_type;
+                CompetitionType logType = Enum.Parse<CompetitionType>(backendData.competition_type);
                 Debug.Log($"[CompetitionManager] Added competition {competitionId} (Type: {logType}, Start: {competition.StartDateTime}, End: {competition.EndDateTime})");
             }
             catch (Exception ex)

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -52,6 +52,10 @@ namespace GlobalCompetitionSystem
         {
             // Parse competition ID
             Guid competitionId = Guid.Parse(backendData.competition_id);
+
+            // Neutral target identifier from backend. Depending on competition type,
+            // this maps to either a fish definition ID or an item definition ID.
+            int targetId = backendData.target_fish_id;
             
             // Parse competition type from string to enum
             CompetitionType competitionType = Enum.Parse<CompetitionType>(backendData.competition_type);
@@ -61,17 +65,17 @@ namespace GlobalCompetitionSystem
             {
                 CompetitionType.MostFish => new MostFishCompetitonState 
                 { 
-                    specificFish = backendData.target_fish_id > 0, 
-                    fishIDToCatch = backendData.target_fish_id 
+                    specificFish = targetId > 0,
+                    fishIDToCatch = targetId
                 },
                 CompetitionType.LargestFish => new largestFishCompetitonState 
                 { 
-                    specificFish = backendData.target_fish_id > 0, 
-                    fishIDToCatch = backendData.target_fish_id 
+                    specificFish = targetId > 0,
+                    fishIDToCatch = targetId
                 },
                 CompetitionType.MostItems => new MostItemsCompetitonState 
                 { 
-                    ItemId = backendData.target_fish_id  // target_fish_id is used for item ID in this case
+                    ItemId = targetId
                 },
                 _ => throw new ArgumentException($"Unknown competition type: {competitionType} ({backendData.competition_type})")
             };

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -389,7 +389,6 @@ namespace GlobalCompetitionSystem
         }
 
         [Server]
-        [Server]
         private static void DistributePrizes()
         {
             if (_currentCompetition == null)

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -11,25 +11,75 @@ namespace GlobalCompetitionSystem
 {
     public class Competition
     {
+        private readonly Guid _competitionId;
         private readonly ICompetitionState _competitionState;
         private readonly DateTime _startDateTime;
         private readonly DateTime _endDateTime;
         private StoreManager.CurrencyType _rewardCurrency;
         // index 0 is the prize for first place, etc...
         private List<int> _prizepool;
+        public Guid CompetitionId => _competitionId;
         public ICompetitionState CompetitionState => _competitionState;
         public DateTime StartDateTime => _startDateTime;
         public DateTime EndDateTime => _endDateTime;
         public StoreManager.CurrencyType RewardCurrency => _rewardCurrency;
         public List<int> Prizepool => _prizepool;
             
-        public Competition(ICompetitionState competitionState, DateTime start, DateTime end, StoreManager.CurrencyType rewardCurrency, List<int> prizepool)
+        public Competition(Guid competitionId, ICompetitionState competitionState, DateTime start, DateTime end, StoreManager.CurrencyType rewardCurrency, List<int> prizepool)
         {
+            _competitionId = competitionId;
             _competitionState = competitionState;
             _startDateTime = start;
             _endDateTime = end;
             _rewardCurrency = rewardCurrency;
             _prizepool = prizepool;
+        }
+        
+        /// <summary>
+        /// Creates a Competition instance from backend CompetitionData
+        /// </summary>
+        public static Competition FromBackendData(CompetitionData backendData)
+        {
+            // Parse competition ID
+            Guid competitionId = Guid.Parse(backendData.competition_id);
+            
+            // Map competition type to ICompetitionState
+            // Backend: 1=MostFish, 2=LargestFish, 3=MostItems
+            ICompetitionState competitionState = backendData.competition_type switch
+            {
+                1 => new MostFishCompetitonState 
+                { 
+                    specificFish = backendData.target_fish_id > 0, 
+                    fishIDToCatch = backendData.target_fish_id 
+                },
+                2 => new largestFishCompetitonState 
+                { 
+                    specificFish = backendData.target_fish_id > 0, 
+                    fishIDToCatch = backendData.target_fish_id 
+                },
+                3 => new MostItemsCompetitonState 
+                { 
+                    ItemId = backendData.target_fish_id  // target_fish_id is used for item ID in this case
+                },
+                _ => throw new ArgumentException($"Unknown competition type: {backendData.competition_type}")
+            };
+            
+            // Parse date times (backend sends ISO 8601 UTC strings)
+            DateTime startTime = DateTime.Parse(backendData.start_time).ToUniversalTime();
+            DateTime endTime = DateTime.Parse(backendData.end_time).ToUniversalTime();
+            
+            // Map currency
+            StoreManager.CurrencyType currency = backendData.reward_currency switch
+            {
+                "COINS" => StoreManager.CurrencyType.COINS,
+                "BUCKS" => StoreManager.CurrencyType.BUCKS,
+                _ => throw new ArgumentException($"Unknown currency type: {backendData.reward_currency}")
+            };
+            
+            // Convert prize pool array to list
+            List<int> prizePool = new List<int>(backendData.prize_pool);
+            
+            return new Competition(competitionId, competitionState, startTime, endTime, currency, prizePool);
         }
     }
     
@@ -167,6 +217,9 @@ namespace GlobalCompetitionSystem
     {
         [SyncVar] private static CurrentCompetition _currentCompetition;
         private static readonly SyncSortedSet<Competition> _upcomingCompetitions = new SyncSortedSet<Competition>(new CompetitionStartDateComparer());
+        private static readonly HashSet<Guid> _loadedCompetitionIds = new HashSet<Guid>();
+        private static DateTime _lastBackendPoll = DateTime.MinValue;
+        private static readonly TimeSpan _pollInterval = TimeSpan.FromMinutes(5); // Poll backend every 5 minutes
 
         public static CurrentCompetition GetCurrentCompetition()
         {
@@ -184,14 +237,26 @@ namespace GlobalCompetitionSystem
             DateTime lastRankingRefresh = DateTime.MinValue;
             // hours, minute, seconds
             TimeSpan timeBetweenRankingRebuilds = new TimeSpan(0, 1, 0);
+            
+            // Initial poll on startup (after short delay)
+            yield return new WaitForSeconds(2);
+            FetchCompetitionsFromBackend();
+            
             while (true)
             {
+                // Poll backend for new competitions periodically
+                if (DateTime.UtcNow - _lastBackendPoll > _pollInterval)
+                {
+                    FetchCompetitionsFromBackend();
+                    _lastBackendPoll = DateTime.UtcNow;
+                }
+                
                 if (_currentCompetition == null)
                 {
                     if (_upcomingCompetitions.Count > 0)
                     {
                         Competition nextCompetition = _upcomingCompetitions.First();
-                        if (nextCompetition.StartDateTime >= DateTime.Now)
+                        if (nextCompetition.StartDateTime <= DateTime.UtcNow)
                         {
                             SetCurrentCompetition(nextCompetition);
                             _upcomingCompetitions.Remove(nextCompetition);
@@ -205,20 +270,87 @@ namespace GlobalCompetitionSystem
                     _currentCompetition = null;
                 }
 
-                if (_currentCompetition != null && DateTime.Now - lastRankingRefresh > timeBetweenRankingRebuilds)
+                if (_currentCompetition != null && DateTime.UtcNow - lastRankingRefresh > timeBetweenRankingRebuilds)
                 {
                     _currentCompetition.CompetitionData.UpdatePlayerRankings();
-                    lastRankingRefresh = DateTime.Now;
+                    lastRankingRefresh = DateTime.UtcNow;
                 }
                 yield return new WaitForSeconds(1);
             }
         }
 
         [Server]
-        public static void AddUpcomingCompetition(ICompetitionState competitionState, DateTime startDate,
+        private static void FetchCompetitionsFromBackend()
+        {
+            Debug.Log("[CompetitionManager] Fetching competitions from backend...");
+            
+            // Fetch active competitions
+            DatabaseCommunications.GetActiveCompetitions((response) =>
+            {
+                if (response != null && response.competitions != null)
+                {
+                    Debug.Log($"[CompetitionManager] Received {response.competitions.Length} active competition(s) from backend");
+                    foreach (var competitionData in response.competitions)
+                    {
+                        ProcessBackendCompetition(competitionData);
+                    }
+                }
+            });
+            
+            // Fetch upcoming competitions
+            DatabaseCommunications.GetUpcomingCompetitions((response) =>
+            {
+                if (response != null && response.competitions != null)
+                {
+                    Debug.Log($"[CompetitionManager] Received {response.competitions.Length} upcoming competition(s) from backend");
+                    foreach (var competitionData in response.competitions)
+                    {
+                        ProcessBackendCompetition(competitionData);
+                    }
+                }
+            });
+        }
+
+        [Server]
+        private static void ProcessBackendCompetition(CompetitionData backendData)
+        {
+            try
+            {
+                Guid competitionId = Guid.Parse(backendData.competition_id);
+                
+                // Skip if we already loaded this competition
+                if (_loadedCompetitionIds.Contains(competitionId))
+                {
+                    return;
+                }
+                
+                // Convert backend data to Unity Competition object
+                Competition competition = Competition.FromBackendData(backendData);
+                
+                // Check if competition is in the past
+                if (competition.EndDateTime < DateTime.UtcNow)
+                {
+                    Debug.Log($"[CompetitionManager] Skipping expired competition {competitionId}");
+                    return;
+                }
+                
+                // Add to upcoming competitions
+                _upcomingCompetitions.Add(competition);
+                _loadedCompetitionIds.Add(competitionId);
+                
+                Debug.Log($"[CompetitionManager] Added competition {competitionId} (Type: {backendData.competition_type}, Start: {competition.StartDateTime}, End: {competition.EndDateTime})");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[CompetitionManager] Error processing backend competition: {ex.Message}");
+            }
+        }
+
+        [Server]
+        public static void AddUpcomingCompetition(Guid competitionId, ICompetitionState competitionState, DateTime startDate,
             DateTime endDate, StoreManager.CurrencyType rewardCurrency, List<int> rewardDistribution)
         {
-            _upcomingCompetitions.Add(new Competition(competitionState, startDate, endDate, rewardCurrency,
+            _upcomingCompetitions.Add(new Competition(competitionId, competitionState, startDate, endDate, rewardCurrency,
                 rewardDistribution));
         }
 
@@ -296,10 +428,42 @@ namespace GlobalCompetitionSystem
         {
             if (_currentCompetition is CurrentCompetition<T> competition)
             {
-                return competition.AddToCompetition(data, playerData);
+                bool success = competition.AddToCompetition(data, playerData);
+                
+                // If score was successfully added, submit to backend
+                if (success)
+                {
+                    SubmitScoreToBackend(playerData.GetUuid());
+                }
+                
+                return success;
             }
 
             return false;
+        }
+
+        [Server]
+        private static void SubmitScoreToBackend(Guid playerId)
+        {
+            if (_currentCompetition == null)
+            {
+                return;
+            }
+
+            Guid competitionId = _currentCompetition.CompetitionData.RunningCompetition.CompetitionId;
+            (int _, PlayerResult result) = _currentCompetition.CompetitionData.GetPlayerResult(playerId);
+            
+            if (result != null)
+            {
+                int score = result.Result;
+                
+                // Submit to backend (fire and forget - backend handles upserts)
+                DatabaseCommunications.SubmitCompetitionScore(competitionId, playerId, score, (response) =>
+                {
+                    // Success - backend will update leaderboard
+                    Debug.Log($"[CompetitionManager] Submitted score {score} for player {playerId} to competition {competitionId}");
+                });
+            }
         }
     }
 

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -403,7 +403,7 @@ namespace GlobalCompetitionSystem
                 PlayerResult winner = winners[i + 1]; // winners is 1-indexed (rank 1, 2, 3...)
                 int prizeAmount = prizes[i]; // prizes is 0-indexed
                 
-                // Give prize to online player (offline players will receive prizes from backend)
+                // Local runtime state update for online players
                 if (GameNetworkManager.connUUID.TryGetValue(winner.PlayerID, out NetworkConnectionToClient playerConnection))
                 {
                     PlayerData playerData = playerConnection.identity.GetComponent<PlayerData>();

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -294,22 +294,14 @@ namespace GlobalCompetitionSystem
             // Fetch active competition
             DatabaseCommunications.GetActiveCompetition((response) =>
             {
-                if (response != null && response.competitions != null)
+                if (response != null && response.competition != null)
                 {
-                    if (response.competitions.Length == 0)
-                    {
-                        Debug.Log("[CompetitionManager] No active competitions from backend");
-                    }
-                    else if (response.competitions.Length == 1)
-                    {
-                        Debug.Log("[CompetitionManager] Received 1 active competition from backend");
-                        ProcessBackendCompetition(response.competitions[0]);
-                    }
-                    else
-                    {
-                        Debug.LogWarning($"[CompetitionManager] Received {response.competitions.Length} active competitions from backend, but only one can be active at a time. Processing first competition only.");
-                        ProcessBackendCompetition(response.competitions[0]);
-                    }
+                    Debug.Log("[CompetitionManager] Received active competition from backend");
+                    ProcessBackendCompetition(response.competition);
+                }
+                else
+                {
+                    Debug.Log("[CompetitionManager] No active competition from backend");
                 }
             });
             

--- a/Assets/Core/Events/Competition.cs
+++ b/Assets/Core/Events/Competition.cs
@@ -372,27 +372,41 @@ namespace GlobalCompetitionSystem
         }
 
         [Server]
+        [Server]
         private static void DistributePrizes()
         {
+            if (_currentCompetition == null)
+            {
+                Debug.LogWarning("[CompetitionManager] Cannot distribute prizes - no current competition");
+                return;
+            }
+
             List<int> prizes = _currentCompetition.CompetitionData.RunningCompetition.Prizepool;
             SortedList<int, PlayerResult> winners = _currentCompetition.CompetitionData.GetTopPerformers(prizes.Count);
-            for (int i = 0; i < winners.Count; i++)
+            
+            Debug.Log($"[CompetitionManager] Distributing prizes to {winners.Count} winner(s)");
+            
+            for (int i = 0; i < winners.Count && i < prizes.Count; i++)
             {
-                PlayerResult winner = winners[i];
+                PlayerResult winner = winners[i + 1]; // winners is 1-indexed (rank 1, 2, 3...)
+                int prizeAmount = prizes[i]; // prizes is 0-indexed
                 bool prizeGiven = false;
                 
+                // Try to give prize to online player
                 if (GameNetworkManager.connUUID.TryGetValue(winner.PlayerID, out NetworkConnectionToClient playerConnection))
                 {
-                    PlayerDataSyncManager syncManager = playerConnection.identity.GetComponent<PlayerDataSyncManager>();
-                    if (syncManager != null)
+                    PlayerData playerData = playerConnection.identity.GetComponent<PlayerData>();
+                    if (playerData != null)
                     {
                         switch (_currentCompetition.CompetitionData.RunningCompetition.RewardCurrency)
                         {
                             case StoreManager.CurrencyType.BUCKS:
-                                //syncManager.ChangeFishBucksAmount(prizes[i], true);
+                                playerData.ChangeFishBucksAmount(prizeAmount, true);
+                                Debug.Log($"[CompetitionManager] Awarded {prizeAmount} BUCKS to online player {winner.PlayerName} (Rank {i + 1})");
                                 break;
                             case StoreManager.CurrencyType.COINS:
-                                //syncManager.ChangeFishCoinsAmount(prizes[i], true);
+                                playerData.ChangeFishCoinsAmount(prizeAmount, true);
+                                Debug.Log($"[CompetitionManager] Awarded {prizeAmount} COINS to online player {winner.PlayerName} (Rank {i + 1})");
                                 break;
                             default:
                                 throw new NotSupportedException($"Currency type {_currentCompetition.CompetitionData.RunningCompetition.RewardCurrency} has not yet been implemented as a reward");
@@ -401,19 +415,12 @@ namespace GlobalCompetitionSystem
                     }
                 }
                 
-                if(!prizeGiven)
+                // If player is offline, send mail notification (mail system will handle currency delivery)
+                if (!prizeGiven)
                 {
-                    switch (_currentCompetition.CompetitionData.RunningCompetition.RewardCurrency)
-                    {
-                        case StoreManager.CurrencyType.BUCKS:
-                            //DatabaseCommunications.ChangeFishBucksAmount(prizes[i], winner.PlayerID);
-                            break;
-                        case StoreManager.CurrencyType.COINS:
-                            //DatabaseCommunications.ChangeFishCoinsAmount(prizes[i], winner.PlayerID);
-                            break;
-                        default:
-                            throw new NotSupportedException($"Currency type {_currentCompetition.CompetitionData.RunningCompetition.RewardCurrency} has not yet been implemented as a reward");
-                    }
+                    string currencyName = _currentCompetition.CompetitionData.RunningCompetition.RewardCurrency == StoreManager.CurrencyType.COINS ? "Coins" : "Bucks";
+                    SendPrizeMail(winner.PlayerID, winner.PlayerName, i + 1, prizeAmount, currencyName);
+                    Debug.Log($"[CompetitionManager] Sent prize mail to offline player {winner.PlayerName} (Rank {i + 1}): {prizeAmount} {currencyName}");
                 }
             }
         }
@@ -421,7 +428,59 @@ namespace GlobalCompetitionSystem
         [Server]
         public static void MailResults()
         {
-         throw new NotImplementedException();   
+            if (_currentCompetition == null)
+            {
+                Debug.LogWarning("[CompetitionManager] Cannot mail results - no current competition");
+                return;
+            }
+
+            // Get all participants
+            List<int> prizes = _currentCompetition.CompetitionData.RunningCompetition.Prizepool;
+            SortedList<int, PlayerResult> allParticipants = _currentCompetition.CompetitionData.GetTopPerformers(100); // Get top 100 or all
+            
+            string competitionName = _currentCompetition.CompetitionData.RunningCompetition.CompetitionState.AsString();
+            
+            // Mail results to all participants
+            foreach (var entry in allParticipants)
+            {
+                int rank = entry.Key;
+                PlayerResult participant = entry.Value;
+                int prizeAmount = (rank - 1 < prizes.Count) ? prizes[rank - 1] : 0;
+                string currencyName = _currentCompetition.CompetitionData.RunningCompetition.RewardCurrency == StoreManager.CurrencyType.COINS ? "Coins" : "Bucks";
+                
+                string title = prizeAmount > 0 
+                    ? $"Competition Winner! - Rank #{rank}" 
+                    : $"Competition Results - Rank #{rank}";
+                    
+                string message = prizeAmount > 0
+                    ? $"Congratulations! You finished rank #{rank} in the '{competitionName}' competition!\n\n" +
+                      $"You won: {prizeAmount} {currencyName}\n\n" +
+                      $"Thank you for participating!"
+                    : $"Thank you for participating in the '{competitionName}' competition!\n\n" +
+                      $"You finished rank #{rank}.\n\n" +
+                      $"Keep practicing and good luck in future competitions!";
+                
+                Mail resultMail = new Mail(participant.PlayerID, title, message, "Competition System");
+                DatabaseCommunications.AddMail(resultMail);
+            }
+            
+            Debug.Log($"[CompetitionManager] Mailed results to {allParticipants.Count} participant(s)");
+        }
+
+        [Server]
+        private static void SendPrizeMail(Guid playerId, string playerName, int rank, int prizeAmount, string currencyName)
+        {
+            string competitionName = _currentCompetition?.CompetitionData.RunningCompetition.CompetitionState.AsString() ?? "Unknown Competition";
+            
+            string title = $"Competition Prize - Rank #{rank}";
+            string message = $"Congratulations {playerName}!\n\n" +
+                           $"You finished rank #{rank} in the '{competitionName}' competition!\n\n" +
+                           $"Your prize: {prizeAmount} {currencyName}\n\n" +
+                           $"(Note: Prize will be added to your account upon your next login)\n\n" +
+                           $"Thank you for participating!";
+            
+            Mail prizeMail = new Mail(playerId, title, message, "Competition System");
+            DatabaseCommunications.AddMail(prizeMail);
         }
 
         public static bool AddToRunningCompetition<T>(T data, PlayerData playerData)

--- a/Assets/Core/Events/CompetitionUIManager.cs
+++ b/Assets/Core/Events/CompetitionUIManager.cs
@@ -19,7 +19,6 @@ namespace  GlobalCompetitionSystem
         [SerializeField] private Transform currentCompetitionsContainerTransform;
         [SerializeField] private TMP_Text competitionEndCountdownText;
         [SerializeField] private TMP_Text competitionStartsInText;
-        [SerializeField] private TMP_Text competitionUuidText; // For debugging
 
         private void Awake()
         {
@@ -105,12 +104,6 @@ namespace  GlobalCompetitionSystem
             }
             currentCompetitionView.SetActive(true);
             CompetitionNotStarted.SetActive(false);
-            
-            // Display competition UUID for debugging
-            if (competitionUuidText != null)
-            {
-                competitionUuidText.text = $"ID: {CompetitionManager.GetCurrentCompetition().CompetitionData.RunningCompetition.CompetitionId}";
-            }
             
             GetComponentInParent<PlayerData>().CmdGetTopPerformers();
         }

--- a/Assets/Core/Events/CompetitionUIManager.cs
+++ b/Assets/Core/Events/CompetitionUIManager.cs
@@ -19,6 +19,7 @@ namespace  GlobalCompetitionSystem
         [SerializeField] private Transform currentCompetitionsContainerTransform;
         [SerializeField] private TMP_Text competitionEndCountdownText;
         [SerializeField] private TMP_Text competitionStartsInText;
+        [SerializeField] private TMP_Text competitionUuidText; // For debugging
 
         private void Awake()
         {
@@ -104,23 +105,46 @@ namespace  GlobalCompetitionSystem
             }
             currentCompetitionView.SetActive(true);
             CompetitionNotStarted.SetActive(false);
+            
+            // Display competition UUID for debugging
+            if (competitionUuidText != null)
+            {
+                competitionUuidText.text = $"ID: {CompetitionManager.GetCurrentCompetition().CompetitionData.RunningCompetition.CompetitionId}";
+            }
+            
             GetComponentInParent<PlayerData>().CmdGetTopPerformers();
         }
 
         private void LoadUpcomingCompetitions(SyncSortedSet<Competition> upcomingCompetitions)
         {
+            // Clear existing entries
+            foreach (Transform child in upcomingCompetitionsContainerTransform)
+            {
+                Destroy(child.gameObject);
+            }
+            
+            // Create new entries with data
             foreach (Competition upcomingCompetition in upcomingCompetitions)
             {
                 GameObject newObject = Instantiate(upcomingCompetitionPreviewObject, upcomingCompetitionsContainerTransform);
+                UpcomingCompetitionUIManager upcomingUI = newObject.GetComponent<UpcomingCompetitionUIManager>();
+                if (upcomingUI != null)
+                {
+                    upcomingUI.SetUpcomingCompetition(upcomingCompetition);
+                }
             }
         }
 
         public void LoadCurrentCompetition(SortedList<int, PlayerResult> rankedPlayerResults, List<int> prizes)
         {
-            if (rankedPlayerResults == null || prizes == null)
+            if (rankedPlayerResults == null)
             {
                 return;
             }
+            
+            // Get prize pool from backend (passed as parameter, but also available from current competition)
+            List<int> prizePool = prizes ?? CompetitionManager.GetCurrentCompetition().CompetitionData.RunningCompetition.Prizepool;
+            
             foreach (Transform child in currentCompetitionsContainerTransform)
             {
                 Destroy(child.gameObject);
@@ -134,12 +158,16 @@ namespace  GlobalCompetitionSystem
             // Convert back to SortedList if absolutely needed
             SortedList<int, PlayerResult> cleanResults = new SortedList<int, PlayerResult>(filtered);
 
+            // Only show leaderboard entries up to the prize pool length (or show all if we want to display non-winners too)
+            // Current implementation shows all players but only awards prizes to top N
             foreach (var kvp in cleanResults)
             {
                 PlayerResult result = kvp.Value;
                 GameObject newObject = Instantiate(currentCompetitionResultObject, currentCompetitionsContainerTransform);
                 PersonalResultsUIManager resultUI = newObject.GetComponent<PersonalResultsUIManager>();
-                int prize = (kvp.Key < prizes.Count) ? prizes[kvp.Key] : 0;
+                
+                // Prize amount is 0 if player rank exceeds prize pool length
+                int prize = (kvp.Key - 1 < prizePool.Count) ? prizePool[kvp.Key - 1] : 0;
                 resultUI.SetResults(kvp.Key, result.PlayerName, result.Result, prize, CompetitionManager.GetCurrentCompetition().CompetitionData.RunningCompetition.RewardCurrency);
             }
         }

--- a/Assets/Core/Events/CompetitionUIManager.cs
+++ b/Assets/Core/Events/CompetitionUIManager.cs
@@ -135,8 +135,7 @@ namespace  GlobalCompetitionSystem
                 return;
             }
             
-            // Get prize pool from backend (passed as parameter, but also available from current competition)
-            List<int> prizePool = prizes ?? CompetitionManager.GetCurrentCompetition().CompetitionData.RunningCompetition.Prizepool;
+            List<int> prizePool = prizes;
             
             foreach (Transform child in currentCompetitionsContainerTransform)
             {

--- a/Assets/Core/Events/MostFishCompetition.cs
+++ b/Assets/Core/Events/MostFishCompetition.cs
@@ -55,7 +55,7 @@ namespace GlobalCompetitionSystem
             string playerName = playerData.GetUsername();
             (int _, PlayerResult result) = CompetitionData.GetPlayerResult(playerId);
             int newScore = 0;
-            if (result.PlayerID != playerId)
+            if (result != null)
             {
                 newScore = result.Result;
             }

--- a/Assets/Core/Events/PersonalResultsUIManager.cs
+++ b/Assets/Core/Events/PersonalResultsUIManager.cs
@@ -30,7 +30,8 @@ namespace GlobalCompetitionSystem
                 _ => throw new NotSupportedException($"Prize type {prize} is not supported")
             };
 
-            if (prize == 0)
+            // Hide prize display if no prize for this rank
+            if (prizeAmount == 0)
             {
                 prizeSpriteImage.enabled = false;
                 prizeAmountText.text = "";

--- a/Assets/Core/Events/UpcomingCompetitionUIManager.cs
+++ b/Assets/Core/Events/UpcomingCompetitionUIManager.cs
@@ -12,19 +12,12 @@ namespace GlobalCompetitionSystem
         [SerializeField] TMP_Text CountdownText;
         [SerializeField] TMP_Text DescriptionText;
         [SerializeField] Image CompetitionIcon;
-        [SerializeField] TMP_Text CompetitionUuidText; // For debugging
 
         public void SetUpcomingCompetition(Competition competition)
         {
             _competition = competition;
             DescriptionText.text = competition.CompetitionState.AsString();
             CompetitionIcon.sprite = competition.CompetitionState.Icon();
-            
-            // Display competition UUID for debugging
-            if (CompetitionUuidText != null)
-            {
-                CompetitionUuidText.text = $"ID: {competition.CompetitionId}";
-            }
         }
 
         private void Update()

--- a/Assets/Core/Events/UpcomingCompetitionUIManager.cs
+++ b/Assets/Core/Events/UpcomingCompetitionUIManager.cs
@@ -12,12 +12,19 @@ namespace GlobalCompetitionSystem
         [SerializeField] TMP_Text CountdownText;
         [SerializeField] TMP_Text DescriptionText;
         [SerializeField] Image CompetitionIcon;
+        [SerializeField] TMP_Text CompetitionUuidText; // For debugging
 
         public void SetUpcomingCompetition(Competition competition)
         {
             _competition = competition;
             DescriptionText.text = competition.CompetitionState.AsString();
             CompetitionIcon.sprite = competition.CompetitionState.Icon();
+            
+            // Display competition UUID for debugging
+            if (CompetitionUuidText != null)
+            {
+                CompetitionUuidText.text = $"ID: {competition.CompetitionId}";
+            }
         }
 
         private void Update()

--- a/Assets/Core/Managers/GameNetworkManager.cs
+++ b/Assets/Core/Managers/GameNetworkManager.cs
@@ -129,6 +129,7 @@ public class GameNetworkManager : NetworkManager
         NetworkServer.RegisterHandler<CreateCharacterMessage>(OnBeginCreateCharacter);
         NetworkServer.RegisterHandler<MovePlayerMessage>(OnPlayerMoveMessage);
         
+        StartCoroutine(CompetitionManager.PollCompetitionsFromBackend());
         StartCoroutine(CompetitionManager.UpdateCompetitions());
     }
 

--- a/Assets/Database communication/DatabaseCommunications.cs
+++ b/Assets/Database communication/DatabaseCommunications.cs
@@ -285,11 +285,11 @@ public static class DatabaseCommunications
     }
 
     [Server]
-    public static void GetActiveCompetitions(WebRequestHandler.WebRequestCallback callback)
+    public static void GetActiveCompetition(WebRequestHandler.WebRequestCallback callback)
     {
         // GET request - send empty body
         byte[] bodyRaw = Encoding.UTF8.GetBytes("{}");
-        WebRequestHandler.SendWebRequest(DatabaseEndpoints.getActiveCompetitionsEndpoint, bodyRaw, null, callback);
+        WebRequestHandler.SendWebRequest(DatabaseEndpoints.getActiveCompetitionEndpoint, bodyRaw, null, callback);
     }
 
     [Server]

--- a/Assets/Database communication/DatabaseCommunications.cs
+++ b/Assets/Database communication/DatabaseCommunications.cs
@@ -283,4 +283,35 @@ public static class DatabaseCommunications
         byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
         WebRequestHandler.SendWebRequest(DatabaseEndpoints.removeExpiredEffectEndpoint, bodyRaw);
     }
+
+    [Server]
+    public static void GetActiveCompetitions(WebRequestHandler.WebRequestCallback callback)
+    {
+        // GET request - send empty body
+        byte[] bodyRaw = Encoding.UTF8.GetBytes("{}");
+        WebRequestHandler.SendWebRequest(DatabaseEndpoints.getActiveCompetitionsEndpoint, bodyRaw, null, callback);
+    }
+
+    [Server]
+    public static void GetUpcomingCompetitions(WebRequestHandler.WebRequestCallback callback)
+    {
+        // GET request - send empty body
+        byte[] bodyRaw = Encoding.UTF8.GetBytes("{}");
+        WebRequestHandler.SendWebRequest(DatabaseEndpoints.getUpcomingCompetitionsEndpoint, bodyRaw, null, callback);
+    }
+
+    [Server]
+    public static void SubmitCompetitionScore(Guid competitionId, Guid playerId, int score, WebRequestHandler.WebRequestCallback callback = null)
+    {
+        SubmitCompetitionScoreRequest requestData = new SubmitCompetitionScoreRequest
+        {
+            competition_id = competitionId.ToString(),
+            player_id = playerId.ToString(),
+            score = score,
+        };
+        
+        string json = JsonUtility.ToJson(requestData);
+        byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+        WebRequestHandler.SendWebRequest(DatabaseEndpoints.submitCompetitionScoreEndpoint, bodyRaw, null, callback);
+    }
 }

--- a/Assets/Database communication/DatabaseEndpoints.cs
+++ b/Assets/Database communication/DatabaseEndpoints.cs
@@ -23,7 +23,7 @@ public static class DatabaseEndpoints
     public static string addActiveEffectEndpoint = serverAddress + "effects/add_effect";
     public static string removeExpiredEffectEndpoint = serverAddress + "effects/remove_expired";
     
-    public static string getActiveCompetitionsEndpoint = serverAddress + "competitions/active";
+    public static string getActiveCompetitionEndpoint = serverAddress + "competitions/active";
     public static string getUpcomingCompetitionsEndpoint = serverAddress + "competitions/upcoming";
     public static string submitCompetitionScoreEndpoint = serverAddress + "competitions/submit_score";
     

--- a/Assets/Database communication/DatabaseEndpoints.cs
+++ b/Assets/Database communication/DatabaseEndpoints.cs
@@ -23,5 +23,9 @@ public static class DatabaseEndpoints
     public static string addActiveEffectEndpoint = serverAddress + "effects/add_effect";
     public static string removeExpiredEffectEndpoint = serverAddress + "effects/remove_expired";
     
+    public static string getActiveCompetitionsEndpoint = serverAddress + "competitions/active";
+    public static string getUpcomingCompetitionsEndpoint = serverAddress + "competitions/upcoming";
+    public static string submitCompetitionScoreEndpoint = serverAddress + "competitions/submit_score";
+    
     public static string getPlayerDataEndpoint = serverAddress + "data/retreive_all_playerdata";
 }

--- a/Assets/Database communication/DatabaseEndpoints.cs
+++ b/Assets/Database communication/DatabaseEndpoints.cs
@@ -23,7 +23,7 @@ public static class DatabaseEndpoints
     public static string addActiveEffectEndpoint = serverAddress + "effects/add_effect";
     public static string removeExpiredEffectEndpoint = serverAddress + "effects/remove_expired";
     
-    public static string getActiveCompetitionEndpoint = serverAddress + "competitions/active";
+    public static string getActiveCompetitionEndpoint = serverAddress + "competition/active";
     public static string getUpcomingCompetitionsEndpoint = serverAddress + "competitions/upcoming";
     public static string submitCompetitionScoreEndpoint = serverAddress + "competitions/submit_score";
     

--- a/Assets/Database communication/DatabaseRequestStructs.cs
+++ b/Assets/Database communication/DatabaseRequestStructs.cs
@@ -221,4 +221,56 @@ public class RemoveExpiredEffectsRequest
     public int item_id = 0;
 }
 
+// Competition requests and data structures
+[Serializable]
+public class CompetitionData
+{
+    public string competition_id = string.Empty;
+    public int competition_type = 0;        // 1=MostFish, 2=LargestFish, 3=MostItems
+    public int target_fish_id = 0;
+    public string start_time = string.Empty;    // DateTime as ISO 8601 string
+    public string end_time = string.Empty;      // DateTime as ISO 8601 string
+    public string reward_currency = string.Empty; // "COINS" or "BUCKS"
+    public int[] prize_pool = new int[0];      // Array of prizes for top N players
+    public string created_at = string.Empty;    // DateTime as ISO 8601 string
+    public string status = string.Empty;        // "SCHEDULED", "ACTIVE", "COMPLETED"
+}
+
+[Serializable]
+public class CompetitionResultData
+{
+    public string result_id = string.Empty;
+    public string competition_id = string.Empty;
+    public string player_id = string.Empty;
+    public int score = 0;
+    public string last_updated = string.Empty;  // DateTime as ISO 8601 string
+}
+
+[Serializable]
+public class GetActiveCompetitionsResponse
+{
+    public CompetitionData[] competitions = new CompetitionData[0];
+}
+
+[Serializable]
+public class GetUpcomingCompetitionsResponse
+{
+    public CompetitionData[] competitions = new CompetitionData[0];
+}
+
+[Serializable]
+public class SubmitCompetitionScoreRequest
+{
+    public string competition_id = string.Empty;
+    public string player_id = string.Empty;
+    public int score = 0;
+}
+
+[Serializable]
+public class LeaderboardResponse
+{
+    public string competition_id = string.Empty;
+    public CompetitionResultData[] results = new CompetitionResultData[0];
+}
+
 #nullable disable

--- a/Assets/Database communication/DatabaseRequestStructs.cs
+++ b/Assets/Database communication/DatabaseRequestStructs.cs
@@ -249,7 +249,7 @@ public class CompetitionResultData
 [Serializable]
 public class GetActiveCompetitionResponse
 {
-    public CompetitionData[] competitions = new CompetitionData[0];
+    public CompetitionData competition = null;
 }
 
 [Serializable]

--- a/Assets/Database communication/DatabaseRequestStructs.cs
+++ b/Assets/Database communication/DatabaseRequestStructs.cs
@@ -247,7 +247,7 @@ public class CompetitionResultData
 }
 
 [Serializable]
-public class GetActiveCompetitionsResponse
+public class GetActiveCompetitionResponse
 {
     public CompetitionData[] competitions = new CompetitionData[0];
 }

--- a/Assets/Database communication/DatabaseRequestStructs.cs
+++ b/Assets/Database communication/DatabaseRequestStructs.cs
@@ -226,7 +226,7 @@ public class RemoveExpiredEffectsRequest
 public class CompetitionData
 {
     public string competition_id = string.Empty;
-    public int competition_type = 0;        // 1=MostFish, 2=LargestFish, 3=MostItems
+    public string competition_type = string.Empty;  // "MostFish", "LargestFish", or "MostItems"
     public int target_fish_id = 0;
     public string start_time = string.Empty;    // DateTime as ISO 8601 string
     public string end_time = string.Empty;      // DateTime as ISO 8601 string


### PR DESCRIPTION
This PR integrates the Unity client with the new competition backend system. The game now polls the backend every 5 minutes and syncs all competition data automatically.

What's added:
- DatabaseEndpoints.cs: New endpoint constants for competition API calls
- DatabaseRequestStructs.cs: CompetitionData, CompetitionResultData, response structs matching backend schema
- DatabaseCommunications.cs: Methods to get active/upcoming competitions and submit scores
- Competition.cs: UUID field for backend competition_id, FromBackendData() factory, backend polling system, SubmitScoreToBackend(), DistributePrizes(), MailResults()
- CompetitionUIManager.cs: Display competition UUID, dynamic prize pool support
- Fixed bugs in MostFishCompetition.cs, PersonalResultsUIManager.cs, UpcomingCompetitionUIManager.cs

What works:
- Unity polls backend every 5 minutes and fetches active/upcoming competitions
- Score submission syncs to backend database in real-time
- Online players get prizes instantly when competitions end
- All participants receive mail notifications with results
- Supports variable-length prize pools (10-50 winners)

Known limitations:
- Offline players only get mail notifications, they don't automatically receive currency yet. We'll need a backend endpoint for mail-based currency delivery or a "claim prize" button in the future.
- Leaderboards currently only show players on the same server, not across the entire database (but scores are properly stored across all servers in the backend).

Feel free to test it out and let me know if you spot any issues!